### PR TITLE
Remove Mojo:: dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -66,8 +66,6 @@ my %WriteMakefile = (
 
 	'PREREQ_PM'     => {
 		'Business::ISBN::Data' => '20140910.002',
-		'Mojo::DOM'            => '0',
-		'Mojo::UserAgent'      => '0',
 		},
 
 	'META_MERGE' => {


### PR DESCRIPTION
Hi, I recently got PAUSE permissions to upload a new version of GD::Barcode which I'm preparing on github here: https://github.com/mbeijen/GD-Barcode

The GD::Barcode module is VERY old and has no tests. So I was looking in downstream modules to see if I could find tests and upstream those, and I stumbled on your module that way.

I noticed you separated some code to fetch stuff online to a separate module but this module still depends on the Mojo:: libs - this PR removes those dependencies.
